### PR TITLE
http: request_parser: fix grammar ambiguity in field_content

### DIFF
--- a/include/seastar/core/ragel.hh
+++ b/include/seastar/core/ragel.hh
@@ -137,4 +137,16 @@ public:
     }
 };
 
+inline void trim_trailing_spaces_and_tabs(sstring& str) {
+    auto data = str.data();
+    size_t i;
+    for (i = str.size(); i > 0; --i) {
+        auto c = data[i-1];
+        if (!(c == ' ' || c == '\t')) {
+            break;
+        }
+    }
+    str.resize(i);
+}
+
 }


### PR DESCRIPTION
`field_vchars` is intended to catch all graphical characters until the next space. But due to an ambiguity in the grammar, after each `(graph | obs_text)`, instead of following to the next character, the parser can concurrently exit `field_vchars`, move to `sp_ht*`, consume 0 times sp_ht, and loop back to `field_vchars`.

As a result, `checkpoint` is called after every character in a field value. This does not change the correctness of parsing, but is a serious performance problem, because it invokes the expensive `sstring::operator+` for each parsed character.
See https://github.com/scylladb/scylladb/pull/12445 for a discussion.

To break the ambiguity, we change the parsing logic of `value` to this list of steps:
1. Skip leading whitespace.
2. Mark beginning of value.
3. Consume until CRLF.
4. Mark end of value.
5. Trim trailing whitespace of value.

At the same time, this series fixes a correctness bug: before the patch, if the parsed buffer fragment ends in the middle of trailing space, the space up until the end is appended to the field value, even though trailing space has to be ignored.

Backported from 8889cbc198214444511ad268ee8e4b80af4747d1. Unlike the original fix, this backport doesn't touch response_parser, because in this branch response_parser isn't affected by the bug (because it doesn't contain
61da78152b `http: Sync response parser with request parser`).