### PR TITLE
reactor: change shares for default IO class from 1 to 200

### DIFF
--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -1716,7 +1716,7 @@ const io_priority_class& default_priority_class() {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     static thread_local auto shard_default_class = [] {
-        return io_priority_class::register_one("default", 1);
+        return io_priority_class::register_one("default", 200);
     }();
     return shard_default_class;
 #pragma GCC diagnostic pop


### PR DESCRIPTION
The number of shares is supposed to be set in the 1-1000 range, and user-defined IO classes have shares on the order of hundreds in practice.

Therefore, 1 share is not a sane default, because the default class can very easily be starved by accident.
We have seen in practice for example in scylladb/scylladb#13753.