### PR TITLE
rpc: backport patches needed for advanced RPC compression

### DIFF
--- a/doc/rpc.md
+++ b/doc/rpc.md
@@ -90,7 +90,13 @@ Actual negotiation looks like this:
     uint32_t len
     uint8_t compressed_data[len]
 
-    after compressed_data is uncompressed it becomes regular request, response or streaming frame 
+    After compressed_data is uncompressed, it becomes a regular request, response or streaming frame.
+
+    As a special case, it is allowed to send a compressed frame of size 0 (pre-compression).
+    Such a frame will be a no-op on the receiver.
+    (This can be used as a means of communication between the compressors themselves.
+    If a compressor wants to send some metadata to its peer, it can send a no-op frame,
+    and prepend the metadata as a compressor-specific header.)
 
 ## Request frame format
     uint64_t timeout_in_ms - only present if timeout propagation is negotiated

--- a/include/seastar/core/sleep.hh
+++ b/include/seastar/core/sleep.hh
@@ -29,6 +29,7 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
+#include <seastar/core/manual_clock.hh>
 #include <seastar/core/timer.hh>
 #include <seastar/util/modules.hh>
 #endif
@@ -94,6 +95,7 @@ future<> sleep_abortable(typename Clock::duration dur, abort_source& as);
 
 extern template future<> sleep_abortable<steady_clock_type>(typename steady_clock_type::duration, abort_source&);
 extern template future<> sleep_abortable<lowres_clock>(typename lowres_clock::duration, abort_source&);
+extern template future<> sleep_abortable<manual_clock>(typename manual_clock::duration, abort_source&);
 
 SEASTAR_MODULE_EXPORT_END
 }

--- a/include/seastar/rpc/rpc.hh
+++ b/include/seastar/rpc/rpc.hh
@@ -306,7 +306,7 @@ protected:
     snd_buf compress(snd_buf buf);
     future<> send_buffer(snd_buf buf);
     future<> send(snd_buf buf, std::optional<rpc_clock_type::time_point> timeout = {}, cancellable* cancel = nullptr);
-    future<> send_entry(outgoing_entry& d);
+    future<> send_entry(outgoing_entry& d) noexcept;
     future<> stop_send_loop(std::exception_ptr ex);
     future<std::optional<rcv_buf>>  read_stream_frame_compressed(input_stream<char>& in);
     bool stream_check_twoway_closed() const noexcept {

--- a/include/seastar/rpc/rpc_types.hh
+++ b/include/seastar/rpc/rpc_types.hh
@@ -276,6 +276,7 @@ public:
     // decompress data
     virtual rcv_buf decompress(rcv_buf data) = 0;
     virtual sstring name() const = 0;
+    virtual future<> close() noexcept { return make_ready_future<>(); };
     
     // factory to create compressor for a connection
     class factory {
@@ -284,6 +285,12 @@ public:
         // return feature string that will be sent as part of protocol negotiation
         virtual const sstring& supported() const = 0;
         // negotiate compress algorithm
+        // send_empty_frame() requests an empty frame to be sent to the peer compressor on the other side of the connection. 
+        // By attaching a header to this empty frame, the compressor can communicate somthing to the peer,
+        // send_empty_frame() mustn't be called from inside compress() or decompress().
+        virtual std::unique_ptr<compressor> negotiate(sstring feature, bool is_server, std::function<future<>()> send_empty_frame) const {
+            return negotiate(feature, is_server);
+        }
         virtual std::unique_ptr<compressor> negotiate(sstring feature, bool is_server) const = 0;
     };
 };

--- a/src/core/future-util.cc
+++ b/src/core/future-util.cc
@@ -135,5 +135,6 @@ future<> sleep_abortable(typename Clock::duration dur, abort_source& as) {
 
 template future<> sleep_abortable<steady_clock_type>(typename steady_clock_type::duration, abort_source&);
 template future<> sleep_abortable<lowres_clock>(typename lowres_clock::duration, abort_source&);
+template future<> sleep_abortable<manual_clock>(typename manual_clock::duration, abort_source&);
 
 }

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -462,12 +462,18 @@ namespace rpc {
               }
               auto ptr = compress_header.get();
               auto size = read_le<uint32_t>(ptr);
-              return read_rcv_buf(in, size).then([this, size, &compressor, info] (rcv_buf compressed_data) {
+              return read_rcv_buf(in, size).then([this, size, &compressor, info, &in] (rcv_buf compressed_data) {
                   if (compressed_data.size != size) {
                       _logger(info, format("unexpected eof on a {} while reading compressed data: expected {:d} got {:d}", FrameType::role(), size, compressed_data.size));
                       return FrameType::empty_value();
                   }
                   auto eb = compressor->decompress(std::move(compressed_data));
+                  if (eb.size == 0) {
+                      // Empty frames might be sent as means of communication between the compressors, and should be skipped by the RPC layer.
+                      // We skip the empty frame here. We recursively restart the function, as if the empty frame didn't happen.
+                      // The yield() is here to limit the stack depth of the recursion to 1.
+                      return yield().then([this, info, &in, &compressor] { return read_frame_compressed<FrameType>(info, compressor, in); });
+                  }
                   net::packet p;
                   auto* one = std::get_if<temporary_buffer<char>>(&eb.bufs);
                   if (one) {

--- a/src/rpc/rpc.cc
+++ b/src/rpc/rpc.cc
@@ -133,7 +133,8 @@ namespace rpc {
       }
   }
 
-  future<> connection::send_entry(outgoing_entry& d) {
+  future<> connection::send_entry(outgoing_entry& d) noexcept {
+    return futurize_invoke([this, &d] {
       if (_propagate_timeout) {
           static_assert(snd_buf::chunk_size >= sizeof(uint64_t), "send buffer chunk size is too small");
           if (_timeout_negotiated) {
@@ -153,6 +154,7 @@ namespace rpc {
           _stats.sent_messages++;
           return _write_buf.flush();
       });
+    });
   }
 
   void connection::set_negotiated() noexcept {

--- a/tests/unit/abort_source_test.cc
+++ b/tests/unit/abort_source_test.cc
@@ -80,6 +80,20 @@ SEASTAR_TEST_CASE(test_sleep_abortable) {
     return f.finally([as = std::move(as)] { });
 }
 
+SEASTAR_TEST_CASE(test_sleep_abortable_no_abort) {
+    auto as = std::make_unique<abort_source>();
+
+    // Check that the sleep completes as usual if the
+    // abort source doesn't fire.
+    auto f = sleep_abortable<manual_clock>(100s, *as);
+    manual_clock::advance(99s);
+    BOOST_REQUIRE(!f.available());
+    manual_clock::advance(101s);
+    return f.finally([as = std::move(as)] { });
+}
+
+
+
 // Verify that negative sleep does not sleep forever. It should not sleep
 // at all.
 SEASTAR_TEST_CASE(test_negative_sleep_abortable) {

--- a/tests/unit/rpc_test.cc
+++ b/tests/unit/rpc_test.cc
@@ -20,6 +20,8 @@
  */
 
 #include "loopback_socket.hh"
+#include "seastar/core/condition-variable.hh"
+#include "seastar/core/temporary_buffer.hh"
 #include <seastar/rpc/rpc.hh>
 #include <seastar/rpc/rpc_types.hh>
 #include <seastar/rpc/lz4_compressor.hh>
@@ -1548,4 +1550,157 @@ SEASTAR_TEST_CASE(test_rpc_abort_connection) {
         BOOST_REQUIRE_EQUAL(arrived, 2);
         c1.stop().get0();
     });
+}
+
+// Extract a piece of contiguous data from the front of the buffer (and trim the extracted front away).
+template <typename T>
+requires std::is_trivially_copyable_v<T>
+T read_from_rcv_buf(rpc::rcv_buf& data) {
+    if (data.size < sizeof(T)) {
+        throw std::runtime_error("Truncated compressed RPC frame");
+    }
+    auto it = std::get_if<temporary_buffer<char>>(&data.bufs);
+    if (!it) {
+        it = std::get<std::vector<temporary_buffer<char>>>(data.bufs).data();
+    }
+    std::array<T, 1> out;
+    auto out_span = std::as_writable_bytes(std::span(out)).subspan(0);
+    while (out_span.size()) {
+        size_t n = std::min<size_t>(out_span.size(), it->size());
+        std::memcpy(static_cast<void*>(out_span.data()), it->get(), n);
+        out_span = out_span.subspan(n);
+        it->trim_front(n);
+        ++it;
+        data.size -= n;
+    }
+    return out[0];
+}
+
+
+// Test the use of empty compressed frames as a method of communication between compressors.
+SEASTAR_THREAD_TEST_CASE(test_compressor_empty_frames) {
+    static const sstring compressor_name = "TEST";
+    struct tracker {
+        struct compressor;
+        compressor* _compressor;
+
+        // When `send_metadata(x)` is called, this compressor sends a piece of metadata (x) to its peer,
+        // by prepending it to an empty compressed frame.
+        // It can be read from the peer with `receive_metadata()`.
+        struct compressor : public rpc::compressor {
+            tracker& _tracker;
+
+            std::unique_ptr<rpc::compressor> _delegate;
+
+            using metadata = uint64_t;
+            std::deque<metadata> _send_queue;
+            std::deque<metadata> _recv_queue;
+            semaphore _metadata_received{0};
+
+            std::function<future<>()> _send_empty_frame;
+            condition_variable _needs_progress;
+            future<> _progress_fiber;
+
+            future<> start_progress_fiber() {
+                while (true) {
+                    co_await _needs_progress.when([&] { return !_send_queue.empty(); });
+                    co_await _send_empty_frame();
+                }
+            }
+            future<> close() noexcept override {
+                _needs_progress.broken();
+                return std::move(_progress_fiber).handle_exception([] (const auto&) {});
+            }
+            void send_metadata(metadata x) {
+                _send_queue.push_back(x);
+                _needs_progress.signal();
+            }
+            future<metadata> receive_metadata() {
+                co_await _metadata_received.wait();
+                auto x = _recv_queue.front();
+                _recv_queue.pop_front();
+                co_return x;
+            }
+
+            rpc::snd_buf compress(size_t head_space, rpc::snd_buf data) override {
+                if (!_send_queue.empty()) {
+                    auto x = _delegate->compress(head_space + 1 + sizeof(metadata), data.size ? std::move(data) : rpc::snd_buf(temporary_buffer<char>()));
+                    seastar::write_be<uint8_t>(x.front().get_write()+head_space, 1);
+                    seastar::write_be<uint64_t>(x.front().get_write()+head_space+1, _send_queue.front());
+                    _send_queue.pop_front();
+                    return x;
+                } else {
+                    auto x = _delegate->compress(head_space + 1, data.size ? std::move(data) : rpc::snd_buf(temporary_buffer<char>()));
+                    seastar::write_be<uint8_t>(x.front().get_write()+head_space, 0);
+                    return x;
+                }
+            }
+            rpc::rcv_buf decompress(rpc::rcv_buf data) override {
+                if (net::ntoh(read_from_rcv_buf<uint8_t>(data))) {
+                    _recv_queue.push_back(net::ntoh(read_from_rcv_buf<uint64_t>(data)));
+                    _metadata_received.signal();
+                }
+                return _delegate->decompress(std::move(data));
+            }
+            sstring name() const override {
+                return compressor_name;
+            }
+
+            compressor(tracker& tracker, std::function<future<>()> send_empty_frame)
+                : _tracker(tracker)
+                , _delegate(std::make_unique<rpc::lz4_fragmented_compressor>())
+                , _send_empty_frame(std::move(send_empty_frame))
+                , _progress_fiber(start_progress_fiber())
+            {
+                _tracker._compressor = this;
+            }
+            ~compressor() {
+                _tracker._compressor = nullptr;
+            }
+        };
+
+        struct factory : public rpc::compressor::factory {
+            tracker& _tracker;
+
+            factory(tracker& tracker) : _tracker(tracker) {
+            }
+            const sstring& supported() const override {
+                return compressor_name;
+            }
+            std::unique_ptr<rpc::compressor> negotiate(sstring feature, bool is_server, std::function<future<>()> send_empty_frame) const override {
+                if (feature == supported()) {
+                    return std::make_unique<compressor>(_tracker, std::move(send_empty_frame));
+                }
+                return nullptr;
+            }
+            std::unique_ptr<rpc::compressor> negotiate(sstring feature, bool is_server) const override {
+                abort();
+            }
+        };
+    };
+
+    tracker server_tracker;
+    tracker client_tracker;
+    tracker::factory server_factory{server_tracker};
+    tracker::factory client_factory{client_tracker};
+    rpc::server_options so{.compressor_factory = &server_factory};
+    rpc::client_options co{.compressor_factory = &client_factory};
+    rpc_test_config cfg;
+    cfg.server_options = so;
+
+    rpc_test_env<>::do_with_thread(cfg, co, [&] (rpc_test_env<>& env, test_rpc_proto::client& c) {
+        // Perform an RPC once to initialize the connection and compressors. 
+        env.register_handler(1, []() { return 42; }).get();
+        auto proto_client = env.proto().make_client<int()>(1);
+        BOOST_REQUIRE_EQUAL(proto_client(c).get(), 42);
+        BOOST_REQUIRE(client_tracker._compressor);
+        BOOST_REQUIRE(server_tracker._compressor);
+        // Check that both compressors can send metadata to each other.
+        for (int i = 0; i < 3; ++i) {
+            client_tracker._compressor->send_metadata(2*i);
+            BOOST_REQUIRE_EQUAL(server_tracker._compressor->receive_metadata().get(), 2*i);
+            server_tracker._compressor->send_metadata(2*i+1);
+            BOOST_REQUIRE_EQUAL(client_tracker._compressor->receive_metadata().get(), 2*i+1);
+        }
+    }).get();
 }


### PR DESCRIPTION
In Scylla Enterprise, we want to backport some new custom RPC compression features. They depend on some details of Seastar's RPC implementation, so this series backports them accordingly.