### PR TITLE
[Backport 2025.4] http: add "Connection: close" header to final server response.

### DIFF
--- a/tests/unit/httpd_test.cc
+++ b/tests/unit/httpd_test.cc
@@ -1814,6 +1814,16 @@ SEASTAR_TEST_CASE(test_bad_chunk_length) {
     }, {"400 Bad Request", "Can't parse chunk size and extensions"}, true, new echo_stream_handler());
 }
 
+SEASTAR_TEST_CASE(test_close_response) {
+    return check_http_reply({
+        "GET /test HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n"
+    }, {"200 OK", "Connection: close"}, true, new echo_stream_handler()).then([] {
+        return check_http_reply({
+            "/test\r\n\r\n"
+        }, {"400 Bad Request", "Connection: close", "Can't parse the request"}, false, new echo_string_handler());
+    });
+}
+
 SEASTAR_TEST_CASE(case_insensitive_header) {
     std::unique_ptr<seastar::http::request> req = std::make_unique<seastar::http::request>();
     req->_headers["conTEnt-LengtH"] = "17";


### PR DESCRIPTION
According to HTTP/1.1 standard (RFC9112 chapter 9.6 Tear-down):
> **A sender SHOULD send a Connection header field containing the "close" connection option when it intends to close a connection.**
> [...] in a response, the same field indicates that the server is going to close this connection after the response message is complete. [...]
> A server that receives a "close" connection option MUST initiate closure of the connection (see below) after it sends the final response to the request that contained the "close" connection option. **The server SHOULD send a "close" connection option in its final response on that connection.**

Fixes #3041
Refs scylladb/scylladb#26298

Closes #3050

(cherry picked from commit 97cec419aaefa8deec03f88c9506a94e5aa61a11)