### PR TITLE
[Backport 2025.3] all commits required for enabling i7i support

### DIFF
--- a/apps/iotune/iotune.cc
+++ b/apps/iotune/iotune.cc
@@ -322,13 +322,16 @@ public:
 std::chrono::duration<double>
 warmup_period(std::chrono::duration<double> duration) {
     auto min_warmup = 3s;
-    auto five_percent = duration / 5;
-    return min_warmup.count() > five_percent.count() ? min_warmup : five_percent;
+    auto five_percent = duration * 0.05;
+    return std::max(min_warmup, std::chrono::duration_cast<std::chrono::seconds>(five_percent));
 }
 
 class io_worker {
     class requests_rate_meter {
-        std::vector<unsigned>& _rates;
+        std::vector<unsigned> _rates;
+        // Passed in rates might be reused so we locally track in our own vector
+        // (such that we can modify that list) and append later.
+        std::vector<unsigned>& _parent_rates;
         const unsigned& _requests;
         unsigned _prev_requests = 0;
         std::chrono::duration<double> _duration;
@@ -338,7 +341,8 @@ class io_worker {
 
     public:
         requests_rate_meter(std::chrono::duration<double> duration, std::vector<unsigned>& rates, const unsigned& requests)
-            : _rates(rates)
+            : _rates()
+            , _parent_rates(rates)
             , _requests(requests)
             , _duration(duration)
             , _tick([this] {
@@ -359,9 +363,14 @@ class io_worker {
                 _rates.push_back(_requests);
             }
 
-            // drop samples that got measured during the warm up period
-            size_t samples_to_drop = warmup_period(_duration) / period;
+            // Drop samples that got measured during the warm up period.
+            // We drop an extra sample. This is because the one second timer
+            // logic is really independent of when we start counting requests in
+            // `issue_request` itself so the first bucket might not be a full
+            // measurement and cause skew otherwise.
+            size_t samples_to_drop = warmup_period(_duration) / period + 1;
             _rates.erase(_rates.begin(), _rates.begin() + std::min(samples_to_drop, _rates.size()));
+            _parent_rates.insert(_parent_rates.end(), _rates.begin(), _rates.end());
         }
     };
 

--- a/apps/iotune/iotune.cc
+++ b/apps/iotune/iotune.cc
@@ -778,6 +778,8 @@ int main(int ac, char** av) {
         ("random-read-io-buffer-size", bpo::value<unsigned>()->default_value(0), "force buffer size for random read")
         ("force-io-depth", bpo::value<unsigned>()->default_value(0), "force io depth to a certain size (overriding auto detection logic)")
         ("get-best-iops-with-buffer-sizes", bpo::value<std::vector<uint64_t>>()->default_value(std::vector<uint64_t>{}, ""), "run IOPS tests with buffer sizes passed as arg and choose the best combination")
+        ("sequential_read_buffer_size", bpo::value<uint64_t>()->default_value(1 << 20), "Set the sequential buffer size used for read bandwidth calculation. Default is 1MiB")
+        ("sequential_write_buffer_size", bpo::value<uint64_t>()->default_value(1 << 20), "Set the sequential buffer size used for write bandwidth calculation. Default is 1MiB")
     ;
 
     return app.run(ac, av, [&] {
@@ -797,7 +799,8 @@ int main(int ac, char** av) {
                                     "The options are mutually exclusive, please unset one of them.");
                 return 1;
             }
-
+            auto sequential_read_buffer_size = configuration["sequential_read_buffer_size"].as<uint64_t>();
+            auto sequential_write_buffer_size = configuration["sequential_write_buffer_size"].as<uint64_t>();
 
             bool read_saturation, write_saturation;
             if (saturation == "") {
@@ -904,9 +907,8 @@ int main(int ac, char** av) {
                 fmt::print("Measuring sequential write bandwidth: ");
                 std::cout.flush();
                 io_rates write_bw;
-                size_t sequential_buffer_size = 1 << 20;
                 for (unsigned shard = 0; shard < smp::count; ++shard) {
-                    write_bw += iotune_tests.write_sequential_data(shard, sequential_buffer_size, duration * 0.70 / smp::count).get();
+                    write_bw += iotune_tests.write_sequential_data(shard, sequential_write_buffer_size, duration * 0.70 / smp::count).get();
                 }
                 write_bw.bytes_per_sec /= smp::count;
                 rates = iotune_tests.get_serial_rates().get();
@@ -917,13 +919,13 @@ int main(int ac, char** av) {
                 if (write_saturation) {
                     fmt::print("Measuring write saturation length: ");
                     std::cout.flush();
-                    write_sat = iotune_tests.saturate_write(write_bw.bytes_per_sec * (1.0 - rates.stdev_percents()), sequential_buffer_size/2, duration * 0.70).get();
+                    write_sat = iotune_tests.saturate_write(write_bw.bytes_per_sec * (1.0 - rates.stdev_percents()), sequential_write_buffer_size/2, duration * 0.70).get();
                     fmt::print("{}\n", *write_sat);
                 }
 
                 fmt::print("Measuring sequential read bandwidth: ");
                 std::cout.flush();
-                auto read_bw = iotune_tests.read_sequential_data(0, sequential_buffer_size, duration * 0.1).get();
+                auto read_bw = iotune_tests.read_sequential_data(0, sequential_read_buffer_size, duration * 0.1).get();
                 rates = iotune_tests.get_serial_rates().get();
                 fmt::print("{} MB/s{}\n", uint64_t(read_bw.bytes_per_sec / (1024 * 1024)), accuracy_msg());
 
@@ -932,7 +934,7 @@ int main(int ac, char** av) {
                 if (read_saturation) {
                     fmt::print("Measuring read saturation length: ");
                     std::cout.flush();
-                    read_sat = iotune_tests.saturate_read(read_bw.bytes_per_sec * (1.0 - rates.stdev_percents()), sequential_buffer_size/2, duration * 0.1).get();
+                    read_sat = iotune_tests.saturate_read(read_bw.bytes_per_sec * (1.0 - rates.stdev_percents()), sequential_read_buffer_size/2, duration * 0.1).get();
                     fmt::print("{}\n", *read_sat);
                 }
 

--- a/apps/iotune/iotune.cc
+++ b/apps/iotune/iotune.cc
@@ -37,6 +37,7 @@
 #include <wordexp.h>
 #include <yaml-cpp/yaml.h>
 #include <fmt/printf.h>
+#include <fmt/ranges.h>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/thread.hh>
@@ -776,6 +777,7 @@ int main(int ac, char** av) {
         ("random-write-io-buffer-size", bpo::value<unsigned>()->default_value(0), "force buffer size for random write")
         ("random-read-io-buffer-size", bpo::value<unsigned>()->default_value(0), "force buffer size for random read")
         ("force-io-depth", bpo::value<unsigned>()->default_value(0), "force io depth to a certain size (overriding auto detection logic)")
+        ("get-best-iops-with-buffer-sizes", bpo::value<std::vector<uint64_t>>()->default_value(std::vector<uint64_t>{}, ""), "run IOPS tests with buffer sizes passed as arg and choose the best combination")
     ;
 
     return app.run(ac, av, [&] {
@@ -789,6 +791,13 @@ int main(int ac, char** av) {
             auto random_write_io_buffer_size = configuration["random-write-io-buffer-size"].as<unsigned>();
             auto random_read_io_buffer_size = configuration["random-read-io-buffer-size"].as<unsigned>();
             auto force_io_depth = configuration["force-io-depth"].as<unsigned>();
+            auto buffer_sizes_for_best_iops = configuration["get-best-iops-with-buffer-sizes"].as<std::vector<uint64_t>>();
+            if (!buffer_sizes_for_best_iops.empty() && (random_read_io_buffer_size || random_write_io_buffer_size)) {
+                iotune_logger.error("--get-best-iops-with-buffer-sizes is set, but random-read-io-buffer-size or random-write-io-buffer-size are also set. "
+                                    "The options are mutually exclusive, please unset one of them.");
+                return 1;
+            }
+
 
             bool read_saturation, write_saturation;
             if (saturation == "") {
@@ -927,26 +936,39 @@ int main(int ac, char** av) {
                     fmt::print("{}\n", *read_sat);
                 }
 
-                fmt::print("Measuring random write IOPS: ");
-                std::cout.flush();
-                auto write_iops = iotune_tests.write_random_data(test_directory.minimum_io_size(), duration * 0.1).get();
-                rates = iotune_tests.get_sharded_worst_rates().get();
-                fmt::print("{} IOPS{}\n", uint64_t(write_iops.iops), accuracy_msg());
-
-                fmt::print("Measuring random read IOPS: ");
-                std::cout.flush();
-                auto read_iops = iotune_tests.read_random_data(test_directory.minimum_io_size(), duration * 0.1).get();
-                rates = iotune_tests.get_sharded_worst_rates().get();
-                fmt::print("{} IOPS{}\n", uint64_t(read_iops.iops), accuracy_msg());
-
                 struct disk_descriptor desc;
                 desc.mountpoint = mountpoint;
-                desc.read_iops = read_iops.iops;
                 desc.read_bw = read_bw.bytes_per_sec;
                 desc.read_sat_len = read_sat;
-                desc.write_iops = write_iops.iops;
                 desc.write_bw = write_bw.bytes_per_sec;
                 desc.write_sat_len = write_sat;
+
+                if (buffer_sizes_for_best_iops.empty()) {
+                    buffer_sizes_for_best_iops = {test_directory.minimum_io_size()};
+                } else {
+                    fmt::print("Evaluating various buffer sizes for choosing the best IOPS: {}\n", buffer_sizes_for_best_iops);
+                    std::cout.flush();
+                }
+                io_rates best_write_iops, best_read_iops;
+                for (uint64_t buffer_size : buffer_sizes_for_best_iops) {
+                    fmt::print("Measuring random write IOPS: ");
+                    std::cout.flush();
+                    auto write_iops = iotune_tests.write_random_data(buffer_size, duration * 0.1).get();
+                    rates = iotune_tests.get_sharded_worst_rates().get();
+                    fmt::print("{} IOPS{}\n", uint64_t(write_iops.iops), accuracy_msg());
+
+                    fmt::print("Measuring random read IOPS: ");
+                    std::cout.flush();
+                    auto read_iops = iotune_tests.read_random_data(buffer_size, duration * 0.1).get();
+                    rates = iotune_tests.get_sharded_worst_rates().get();
+                    fmt::print("{} IOPS{}\n", uint64_t(read_iops.iops), accuracy_msg());
+
+                    best_write_iops.iops = std::max(best_write_iops.iops, write_iops.iops);
+                    best_read_iops.iops = std::max(best_read_iops.iops, read_iops.iops);
+                }
+
+                desc.read_iops = best_read_iops.iops;
+                desc.write_iops = best_write_iops.iops;
                 disk_descriptors.push_back(std::move(desc));
             }
 

--- a/apps/iotune/iotune.cc
+++ b/apps/iotune/iotune.cc
@@ -336,11 +336,12 @@ class io_worker {
         unsigned _prev_requests = 0;
         std::chrono::duration<double> _duration;
         timer<> _tick;
+        bool _with_warmup;
 
         static constexpr auto period = 1s;
 
     public:
-        requests_rate_meter(std::chrono::duration<double> duration, std::vector<unsigned>& rates, const unsigned& requests)
+        requests_rate_meter(std::chrono::duration<double> duration, std::vector<unsigned>& rates, const unsigned& requests, bool with_warmup)
             : _rates()
             , _parent_rates(rates)
             , _requests(requests)
@@ -349,6 +350,7 @@ class io_worker {
                 _rates.push_back(_requests - _prev_requests);
                 _prev_requests = _requests;
             })
+            , _with_warmup(with_warmup)
         {
             _rates.reserve(256); // ~2 minutes
             if (duration > 4 * period) {
@@ -368,7 +370,7 @@ class io_worker {
             // logic is really independent of when we start counting requests in
             // `issue_request` itself so the first bucket might not be a full
             // measurement and cause skew otherwise.
-            size_t samples_to_drop = warmup_period(_duration) / period + 1;
+            size_t samples_to_drop = _with_warmup ? warmup_period(_duration) / period + 1 : 0;
             _rates.erase(_rates.begin(), _rates.begin() + std::min(samples_to_drop, _rates.size()));
             _parent_rates.insert(_parent_rates.end(), _rates.begin(), _rates.end());
         }
@@ -396,13 +398,13 @@ public:
         return iotune_clock::now() >= _end_load;
     }
 
-    io_worker(size_t buffer_size, std::chrono::duration<double> duration, std::unique_ptr<request_issuer> reqs, std::unique_ptr<position_generator> pos, std::vector<unsigned>& rates)
+    io_worker(size_t buffer_size, std::chrono::duration<double> duration, std::unique_ptr<request_issuer> reqs, std::unique_ptr<position_generator> pos, std::vector<unsigned>& rates, bool with_warmup = true)
         : _buffer_size(buffer_size)
-        , _start_measuring(iotune_clock::now() + std::chrono::duration<double>(warmup_period(duration)))
+        , _start_measuring(iotune_clock::now() + (with_warmup ? std::chrono::duration<double>(warmup_period(duration)) : 0s))
         , _end_measuring(_start_measuring + duration)
         , _end_load(_end_measuring + 10ms)
         , _last_time_seen(_start_measuring)
-        , _rr_meter(duration, rates, _requests)
+        , _rr_meter(duration, rates, _requests, with_warmup)
         , _pos_impl(std::move(pos))
         , _req_impl(std::move(reqs))
     {}
@@ -528,15 +530,15 @@ public:
         });
     }
 
-    future<io_rates> read_workload(size_t buffer_size, pattern access_pattern, unsigned max_os_concurrency, std::chrono::duration<double> duration, std::vector<unsigned>& rates) {
+    future<io_rates> read_workload(size_t buffer_size, pattern access_pattern, unsigned max_os_concurrency, std::chrono::duration<double> duration, std::vector<unsigned>& rates, bool _ = true) {
         buffer_size = calculate_buffer_size(access_pattern, buffer_size, _file.disk_read_dma_alignment(), access_type::read);
         auto worker = std::make_unique<io_worker>(buffer_size, duration, std::make_unique<read_request_issuer>(_file), get_position_generator(buffer_size, access_pattern), rates);
         return do_workload(std::move(worker), max_os_concurrency);
     }
 
-    future<io_rates> write_workload(size_t buffer_size, pattern access_pattern, unsigned max_os_concurrency, std::chrono::duration<double> duration, std::vector<unsigned>& rates) {
+    future<io_rates> write_workload(size_t buffer_size, pattern access_pattern, unsigned max_os_concurrency, std::chrono::duration<double> duration, std::vector<unsigned>& rates, bool with_warmup = true) {
         buffer_size = calculate_buffer_size(access_pattern, buffer_size, _file.disk_write_dma_alignment(), access_type::write);
-        auto worker = std::make_unique<io_worker>(buffer_size, duration, std::make_unique<write_request_issuer>(_file), get_position_generator(buffer_size, access_pattern), rates);
+        auto worker = std::make_unique<io_worker>(buffer_size, duration, std::make_unique<write_request_issuer>(_file), get_position_generator(buffer_size, access_pattern), rates, with_warmup);
         bool update_file_size = worker->is_sequential();
         return do_workload(std::move(worker), max_os_concurrency, update_file_size).then([this] (io_rates r) {
             return _file.flush().then([r = std::move(r)] () mutable {
@@ -604,7 +606,16 @@ public:
 
     future<io_rates> write_sequential_data(unsigned shard, size_t buffer_size, std::chrono::duration<double> duration) {
         return _iotune_test_file.invoke_on(shard, [this, buffer_size, duration] (test_file& tf) {
-            return tf.write_workload(buffer_size, test_file::pattern::sequential, 4 * _test_directory.disks_per_array(), duration, serial_rates);
+            return tf.write_workload(buffer_size, test_file::pattern::sequential, 4 * _test_directory.disks_per_array(), duration, serial_rates, false);
+        });
+    }
+
+    future<> warm_up_sequential_data(size_t buffer_size, std::chrono::duration<double> duration) {
+        return _iotune_test_file.invoke_on_all([this, buffer_size, duration] (test_file& tf) {
+            return tf.write_workload(buffer_size, test_file::pattern::sequential, 4 * _test_directory.disks_per_array(), duration, sharded_rates.local(), false).then([this] (io_rates r) {
+                sharded_rates.local().clear();
+                return make_ready_future<>();
+            });
         });
     }
 
@@ -640,7 +651,7 @@ private:
     template <typename Fn>
     future<uint64_t> saturate(float rate_threshold, size_t buffer_size, std::chrono::duration<double> duration, Fn&& workload) {
         return _iotune_test_file.invoke_on(0, [this, rate_threshold, buffer_size, duration, workload] (test_file& tf) {
-            return (tf.*workload)(buffer_size, test_file::pattern::sequential, 1, duration, serial_rates).then([this, rate_threshold, buffer_size, duration, workload] (io_rates rates) {
+            return (tf.*workload)(buffer_size, test_file::pattern::sequential, 1, duration, serial_rates, true).then([this, rate_threshold, buffer_size, duration, workload] (io_rates rates) {
                 serial_rates.clear();
                 if (rates.bytes_per_sec < rate_threshold) {
                     // The throughput with the given buffer-size is already "small enough", so
@@ -876,6 +887,9 @@ int main(int ac, char** av) {
                 };
 
                 iotune_tests.create_data_file().get();
+
+                fmt::print("Warming up the disk for sequential write job...\n");
+                iotune_tests.warm_up_sequential_data(sequential_write_buffer_size, warmup_period(duration)).get();
 
                 fmt::print("Starting Evaluation. This may take a while...\n");
                 fmt::print("Measuring sequential write bandwidth: ");

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -132,8 +132,8 @@ public:
 
     struct config {
         unsigned id;
-        unsigned long req_count_rate = std::numeric_limits<int>::max();
-        unsigned long blocks_count_rate = std::numeric_limits<int>::max();
+        unsigned long req_count_rate = std::numeric_limits<unsigned long>::max();
+        unsigned long blocks_count_rate = std::numeric_limits<unsigned long>::max();
         unsigned disk_req_write_to_read_multiplier = read_request_base_count;
         unsigned disk_blocks_write_to_read_multiplier = read_request_base_count;
         size_t disk_read_saturation_length = std::numeric_limits<size_t>::max();
@@ -234,6 +234,10 @@ private:
 
     static fair_group::config make_fair_group_config(const io_queue::config& qcfg) noexcept;
     priority_class_data& find_or_create_class(internal::priority_class pc);
+
+    inline size_t max_request_length(int dnl_idx) const noexcept {
+        return _max_request_length[dnl_idx];
+    }
 };
 
 inline const io_queue::config& io_queue::get_config() const noexcept {

--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -215,8 +215,18 @@ private:
     friend struct ::io_queue_for_tests;
     friend const fair_group& internal::get_fair_group(const io_queue& ioq, unsigned stream);
 
+    /*
+     * This value is used as a cut-off point for calculating the maximum request length.
+     * We look for max(2^i) such that capacity(2^i) < maximum capacity. If 2^i gets bigger
+     * than this value, we stop looking and the maximum request length is set to this value.
+     */
+    static constexpr unsigned request_length_limit = 16 << 20; // 16 MiB
+
     const io_queue::config _config;
-    size_t _max_request_length[2];
+    size_t _max_request_length[2] = {
+        request_length_limit, // write
+        request_length_limit  // read
+    };
     boost::container::static_vector<fair_group, 2> _fgs;
     std::vector<std::unique_ptr<priority_class_data>> _priority_classes;
     util::spinlock _lock;

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -643,13 +643,35 @@ io_group::io_group(io_queue::config io_cfg, unsigned nr_queues)
         const auto& fg = _fgs[g_idx];
         auto max_cap = fg.maximum_capacity();
         for (unsigned shift = 0; ; shift++) {
-            auto tokens = internal::request_tokens(io_direction_and_length(idx, 1 << (shift + io_queue::block_size_shift)), _config);
+            unsigned long req_length = 1ul << (shift + io_queue::block_size_shift);
+
+            auto tokens = internal::request_tokens(io_direction_and_length(idx, req_length), _config);
             auto cap = fg.tokens_capacity(tokens);
             if (cap > max_cap) {
                 if (shift == 0) {
                     throw std::runtime_error("IO-group limits are too low");
                 }
-                _max_request_length[idx] = 1 << ((shift - 1) + io_queue::block_size_shift);
+
+                // The current shift will give us the biggest power of 2 request length for which
+                // capacity is still less than max_cap, but request_length_limit might be a better
+                // fit if tokens_capacity for that is closer to max_cap.
+                auto fitting_req_length = 1ul << (shift - 1 + io_queue::block_size_shift);
+                auto fitting_cap = fg.tokens_capacity(internal::request_tokens(io_direction_and_length(idx, fitting_req_length), _config));
+                auto cap_limit = fg.tokens_capacity(internal::request_tokens(io_direction_and_length(idx, io_group::request_length_limit), _config));
+                if (fitting_cap < cap_limit && cap_limit < max_cap) {
+                    _max_request_length[idx] = io_group::request_length_limit;
+                } else {
+                    _max_request_length[idx] = fitting_req_length;
+                }
+                break;
+            }
+
+            // Break this loop if the calculated request length gets larger than the
+            // request length limit. This avoids an infinite loop if the
+            // configured io_properties are huge and capacity ends up being always 0.
+            // _max_request_length will hold default values of io_group::request_length_limit
+            if (req_length > io_group::request_length_limit) {
+                seastar_logger.info("IO queue was unable to find a suitable maximum request length, the search was cut-off early at: {}MB", io_group::request_length_limit >> 20);
                 break;
             }
         };

--- a/tests/unit/io_queue_test.cc
+++ b/tests/unit/io_queue_test.cc
@@ -94,6 +94,14 @@ struct io_queue_for_tests {
     future<size_t> queue_request(internal::priority_class pc, internal::io_direction_and_length dnl, internal::io_request req, io_intent* intent, iovec_keeper iovs) noexcept {
         return queue.queue_request(pc, dnl, std::move(req), intent, std::move(iovs));
     }
+
+    size_t max_request_length(int dnl_idx) const noexcept {
+        return group->max_request_length(dnl_idx);
+    }
+
+    constexpr size_t request_length_limit() const noexcept {
+        return io_group::request_length_limit;
+    }
 };
 
 internal::priority_class get_default_pc() {
@@ -509,4 +517,19 @@ SEASTAR_TEST_CASE(test_request_iovec_split) {
     seastar_logger.info("{} iters ({} no-splits, {} no-tails)", iter, no_splits, no_tails);
 
     return make_ready_future<>();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_unconfigured_io_queue) {
+    io_queue_for_tests tio;
+
+    BOOST_CHECK_EQUAL(tio.max_request_length(internal::io_direction_and_length::read_idx), tio.request_length_limit());
+    BOOST_CHECK_EQUAL(tio.max_request_length(internal::io_direction_and_length::write_idx), tio.request_length_limit());
+
+    for (uint64_t reqsize = 512; reqsize < 128 << 10; reqsize <<= 1) {
+        auto cost_read = tio.queue.request_capacity(internal::io_direction_and_length(internal::io_direction_and_length::read_idx, reqsize));
+        auto cost_write = tio.queue.request_capacity(internal::io_direction_and_length(internal::io_direction_and_length::write_idx, reqsize));
+
+        BOOST_CHECK_EQUAL(cost_read, 0);
+        BOOST_CHECK_EQUAL(cost_write, 0);
+    }
 }


### PR DESCRIPTION
This PR cherry-picks all commits required for enabling i7i/i8g support.
The list of commits as taken from the ref'd issue below:
- [ ] https://github.com/scylladb/seastar/commit/54533f3a6497aef9e86eecaf8972c591cc2e4e50
- [ ] https://github.com/scylladb/seastar/commit/2322d359444af9d0b4c554d6d69cbdb8193d9fdc
- [ ] https://github.com/scylladb/seastar/commit/1f89c344064b04cd8482709d4b854307d9cb3c73
- [ ] https://github.com/scylladb/seastar/commit/cc691465708fd6cd6286a0c10c205a0af967a43f
- [ ] https://github.com/scylladb/seastar/commit/359093bf787edf72dc940398994d254d3d56d764
- [ ] https://github.com/scylladb/seastar/commit/d3fbad790871e8ef001d0ff74eda7d01d7f9a2aa
- [ ] https://github.com/scylladb/seastar/commit/b16513a29c39103846f042dae9ea3baa56a183a6
- [ ] https://github.com/scylladb/seastar/commit/4a35f9f83f2648c59b8529279d311b19bdd4e51e
- [ ] https://github.com/scylladb/seastar/commit/4fe87576db66d7df5799819e980f3131fed9718d

Refs https://github.com/scylladb/scylladb/issues/26531