### PR TITLE
[Backport 2025.4] scripts: add 'integer' type to seastar-json2code 

### DIFF
--- a/scripts/seastar-json2code.py
+++ b/scripts/seastar-json2code.py
@@ -45,7 +45,7 @@ parser.add_argument('--create-cc', dest='create_cc', action='store_true', defaul
 config = parser.parse_args()
 
 
-valid_vars = {'string': 'sstring', 'int': 'int', 'double': 'double',
+valid_vars = {'string': 'sstring', 'int': 'int', 'integer': 'int', 'double': 'double',
              'float': 'float', 'long': 'long', 'boolean': 'bool', 'char': 'char',
              'datetime': 'json::date_time'}
 

--- a/tests/unit/api.json
+++ b/tests/unit/api.json
@@ -94,6 +94,9 @@
           "items": {
             "type": "int"
           }
+        },
+        "integer_var": {
+          "type": "integer"
         }
       }
     }


### PR DESCRIPTION
Swagger 2.0 expects the integer type to be named integer, whereas
seastar-json2code only supports the int type. As a result, running
seastar-json2code on a model that contains the integer type fails.

This commit extends the list of supported types to allow integer
in addition to int. The old naming (int) is retained for backward
compatibility.

Additionally, tests/unit/api.json is extended to include the 'integer'
type in the model so the json2code script parses it and validates
the fix for issue https://github.com/scylladb/seastar/issues/3103.

Fixes: https://github.com/scylladb/seastar/issues/3103

The motivation for this backport is using fixed `json2code` in
2025.4, to facilitate backporting https://github.com/scylladb/scylladb/pull/27323 to 2025.4.