### PR TITLE
[Backport 2026.1] coroutine/generator: fix setup of generator's waiting task

### DIFF
--- a/include/seastar/coroutine/generator.hh
+++ b/include/seastar/coroutine/generator.hh
@@ -127,7 +127,7 @@ public:
 
     yield_awaiter final_suspend() noexcept {
         _value = nullptr;
-        return {this, this->_consumer};
+        return {this->_consumer};
     }
 
     void unhandled_exception() noexcept {
@@ -136,7 +136,7 @@ public:
 
     yield_awaiter yield_value(Yielded&& value) noexcept {
         this->_value = std::addressof(value);
-        return {this, this->_consumer};
+        return {this->_consumer};
     }
 
     copy_awaiter yield_value(const yielded_deref_type& value)
@@ -147,7 +147,7 @@ public:
                   std::constructible_from<
                     yielded_decvref_type,
                     const yielded_deref_type&>) {
-        return {this, this->_consumer, yielded_decvref_type(value), _value};
+        return {this->_consumer, yielded_decvref_type(value), _value};
     }
 
     void return_void() noexcept {}
@@ -179,7 +179,6 @@ private:
 
 template <typename Yielded>
 struct generator_promise_base<Yielded>::yield_awaiter final {
-    generator_promise_base* _promise;
     std::coroutine_handle<> _consumer;
 
     bool await_ready() const noexcept {
@@ -187,7 +186,6 @@ struct generator_promise_base<Yielded>::yield_awaiter final {
     }
     template <typename Promise>
     std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> producer) noexcept {
-        _promise->_waiting_task = &producer.promise();
         if (seastar::need_preempt()) {
             auto consumer = std::coroutine_handle<seastar::task>::from_address(
                 _consumer.address());
@@ -201,7 +199,6 @@ struct generator_promise_base<Yielded>::yield_awaiter final {
 
 template <typename Yielded>
 struct generator_promise_base<Yielded>::copy_awaiter final {
-    generator_promise_base* _promise;
     std::coroutine_handle<> _consumer;
     yielded_decvref_type _value;
     value_ptr_type& _value_ptr;
@@ -213,8 +210,6 @@ struct generator_promise_base<Yielded>::copy_awaiter final {
     std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> producer) noexcept {
         _value_ptr = std::addressof(_value);
 
-        auto& current = producer.promise();
-        _promise->_waiting_task = &current;
         if (seastar::need_preempt()) {
             auto consumer = std::coroutine_handle<seastar::task>::from_address(
                 _consumer.address());
@@ -429,7 +424,9 @@ public:
 
         std::coroutine_handle<> await_suspend(std::coroutine_handle<> consumer) noexcept {
             auto& promise = _gen->_coro.promise();
+            auto consumer_handle = std::coroutine_handle<seastar::task>::from_address(consumer.address());
             promise._consumer = consumer;
+            promise._waiting_task = &consumer_handle.promise();
             // Check if we need to preempt. If not, directly resume producer.
             // If yes, schedule the producer through the scheduler.
             if (!seastar::need_preempt()) {
@@ -591,7 +588,7 @@ public:
 
     yield_awaiter final_suspend() noexcept {
         _finished = true;
-        return yield_awaiter{this, this->_consumer, true};
+        return yield_awaiter{this->_consumer, true};
     }
 
     void unhandled_exception() noexcept {
@@ -605,7 +602,7 @@ public:
         // Should we suspend and let consumer drain the buffer?
         // Suspend if: buffer is full OR we need to yield to other tasks
         bool should_suspend = !can_push_more(_buffer) || seastar::need_preempt();
-        return yield_awaiter{this, this->_consumer, should_suspend};
+        return yield_awaiter{this->_consumer, should_suspend};
     }
 
     // Yield a range/slice of elements (C++23 ranges support)
@@ -629,7 +626,7 @@ public:
 
         // All elements added, check if we should suspend
         bool should_suspend = !can_push_more(_buffer) || seastar::need_preempt();
-        return yield_awaiter{this, this->_consumer, should_suspend};
+        return yield_awaiter{this->_consumer, should_suspend};
     }
 
     void return_void() noexcept {}
@@ -666,15 +663,12 @@ private:
 
 template <bounded_container Container>
 struct generator_promise_base<Container>::yield_awaiter final {
-    generator_promise_base* _promise;
     std::coroutine_handle<> _consumer;
     bool _should_suspend;
 public:
-    yield_awaiter(generator_promise_base* promise,
-                  std::coroutine_handle<> consumer,
+    yield_awaiter(std::coroutine_handle<> consumer,
                   bool should_suspend) noexcept
-        : _promise{promise}
-        , _consumer{consumer}
+        : _consumer{consumer}
         , _should_suspend{should_suspend}
     {}
     bool await_ready() const noexcept {
@@ -682,7 +676,6 @@ public:
     }
     template <typename Promise>
     std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> producer) noexcept {
-        _promise->_waiting_task = &producer.promise();
         if (seastar::need_preempt()) {
             auto consumer = std::coroutine_handle<seastar::task>::from_address(
                 _consumer.address());
@@ -831,7 +824,9 @@ public:
         std::coroutine_handle<> await_suspend(std::coroutine_handle<> consumer) {
             // Buffer is empty, need to resume producer to get more elements
             auto& promise = _gen->_coro.promise();
+            auto consumer_handle = std::coroutine_handle<seastar::task>::from_address(consumer.address());
             promise._consumer = consumer;
+            promise._waiting_task = &consumer_handle.promise();
 
             // Clear the buffer before resuming producer
             promise.buffer().clear();

--- a/tests/unit/generator_test.cc
+++ b/tests/unit/generator_test.cc
@@ -20,6 +20,7 @@
  */
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/loop.hh>
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/generator.hh>
 #include <seastar/coroutine/exception.hh>
@@ -490,4 +491,23 @@ SEASTAR_TEST_CASE(test_can_push_more_cpo) {
     }
 
     co_return;
+}
+
+// Reproduces issue #3380
+SEASTAR_TEST_CASE(test_generator_waiting_task_no_infinite_loop) {
+    auto gen = [&]() -> coroutine::experimental::generator<int> {
+        co_yield 0;
+        co_await parallel_for_each(std::views::iota(0, 10000), [](int) {
+            return yield();
+        });
+        co_yield 1;
+    }();
+    // First yield would set the generator's waiting task to itself
+    auto val = co_await gen();
+    BOOST_REQUIRE_EQUAL(*val, 0);
+    // To reach the second yield, the generator must finish a large number of concurrent tasks, which should
+    // cause a dump of tasks in the task queue. If the generator's waiting task was set to itself,
+    // the dump would never finish.
+    auto val2 = co_await gen();
+    BOOST_REQUIRE_EQUAL(*val2, 1);
 }


### PR DESCRIPTION
When we dump tasks in `reactor::task_queue::do_dump`, we walk the continuation chains of each tasks using `waiting_task()`. For a generator coroutine task, this `_waiting_task` was incorrectly set to the generator itself, instead of its caller. Additionally, it was only set when a value was `co_yield`ed, so if it spawned some tasks before that, we couldn't have seen the full continuation chains of them.

In this patch we fix this by setting the `_waiting_task` of the generator to its caller in the call_awaiter constructor, and we remove setting of the `_waiting_task` from `yield_awaiter` and `copy_awaiter`. The `_promise` field in these classes is no longer used so it's also removed.

We also add a test that reproduces the infinite continuation chain walk in `tests/unit/generator_test.cc`. Note that we can't use `current_tasktrace()` there because this continuation chain walk limits the number of tasks to 16 (`tasktrace::vector_type::max_size()`), so instead we force the dump by spawning many tasks. The test never finishes without the fix and when the fix is applied, the "Too long queue accumulated for ..." warn message is correctly printed and test finishes quickly.

Fixes #3380

(cherry picked from commit 00867a5c8a2929c9833538efa68b9dd48d1aadd4)