### PR TITLE
reactor_backend: prevent AIO retry loop during shutdown

### DIFF
--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -130,10 +130,32 @@ aio_storage_context::~aio_storage_context() {
     internal::io_destroy(_io_context);
 }
 
+void aio_storage_context::reap_pending_retries() {
+    auto cancel = [this] (auto& retries) {
+        for (auto iocb : retries) {
+            auto desc = get_user_data<kernel_completion>(*iocb);
+            desc->complete_with(-ECANCELED);
+            _iocb_pool.put_one(iocb);
+        }
+        retries.clear();
+    };
+
+    cancel(_pending_aio_retry);
+    cancel(_aio_retries);
+}
+
 future<> aio_storage_context::stop() noexcept {
+    _stopping = true;
+
+    _r._io_sink.drain([] (const internal::io_request& req, io_completion* desc) -> bool {
+        desc->complete_with(-ECANCELED);
+        return true;
+    });
+
     return std::exchange(_pending_aio_retry_fut, make_ready_future<>()).finally([this] {
         return do_until([this] { return !_iocb_pool.outstanding(); }, [this] {
-            reap_completions(false);
+            reap_completions();
+            reap_pending_retries();
             return make_ready_future<>();
         });
     });
@@ -243,7 +265,7 @@ aio_storage_context::submit_work() {
         did_work = true;
     }
 
-    if (need_to_retry() && !retry_in_progress()) {
+    if (need_to_retry()) {
         schedule_retry();
     }
 
@@ -251,6 +273,10 @@ aio_storage_context::submit_work() {
 }
 
 void aio_storage_context::schedule_retry() {
+    if (!_pending_aio_retry_fut.available() || _stopping) {
+        return;
+    }
+
     // loop until both _pending_aio_retry and _aio_retries are empty.
     // While retrying _aio_retries, new retries may be queued onto _pending_aio_retry.
     _pending_aio_retry_fut = do_until([this] {
@@ -296,6 +322,10 @@ void aio_storage_context::schedule_retry() {
 
 bool aio_storage_context::reap_completions(bool allow_retry)
 {
+    if (_stopping) {
+        allow_retry = false;
+    }
+
     struct timespec timeout = {0, 0};
     auto n = io_getevents(_io_context, 1, max_aio, _ev_buffer, &timeout, _r._cfg.force_io_getevents_syscall);
     if (n == -1 && errno == EINTR) {

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -82,15 +82,14 @@ class aio_storage_context {
     pending_aio_retry_t _pending_aio_retry; // Pending retries iocbs
     pending_aio_retry_t _aio_retries;       // Currently retried iocbs
     future<> _pending_aio_retry_fut = make_ready_future<>();
+    bool _stopping = false;
     internal::linux_abi::io_event _ev_buffer[max_aio];
 
     bool need_to_retry() const noexcept {
         return !_pending_aio_retry.empty() || !_aio_retries.empty();
     }
 
-    bool retry_in_progress() const noexcept {
-        return !_pending_aio_retry_fut.available();
-    }
+    void reap_pending_retries();
 
 public:
     explicit aio_storage_context(reactor& r);


### PR DESCRIPTION
## Problem

`aio_storage_context::stop()` can race with the AIO retry loop.

Before this change, `stop()` exchanged `_pending_aio_retry_fut` with a ready future. That could make `retry_in_progress()` return false while an existing retry loop was still running. A concurrent `submit_work()` could then start a second retry loop, allowing both loops to race over `_aio_retries`, `_pending_aio_retry`, and the iocb pool.

This was observed in Scylla CI as:

```text
gossiping_property_file_snitch_test bad_format_5
aio retry failed: boost::container::bad_alloc
```

## Solution

Add an explicit `_stopping` flag and make shutdown own retry cleanup:

- Set `_stopping` before shutdown starts.
- Prevent `schedule_retry()` from starting a new retry loop while stopping.
- Drain `_io_sink` with `-ECANCELED` during stop.
- Cancel queued `_pending_aio_retry` and `_aio_retries` iocbs during stop.
- Avoid queuing new retries from `reap_completions()` once stopping.

This is a minimal functional backport of the shutdown/retry-loop fix from upstream commit `510f3148700a88456948a235431978f62eaaad57` by @tchaikov, excluding the debug-only iocb tracking and the later retry-loop coroutine refactor.

## Testing

Built the affected release test target:

```bash
./configure.py --mode=release
ninja build/release/test/boost/gossiping_property_file_snitch_test
```

Ran the original failing case with Jenkins-like linux-aio arguments:

```bash
./build/release/test/boost/gossiping_property_file_snitch_test \
  --report_level=no \
  --catch_system_errors=no \
  --run_test=bad_format_5 \
  -- \
  --overprovisioned \
  --unsafe-bypass-fsync=1 \
  --kernel-page-cache=1 \
  --blocked-reactor-notify-ms=2000000 \
  --collectd=0 \
  --max-networking-io-control-blocks=1000 \
  --reactor-backend=linux-aio \
  -c2 -m2G
```

Tested locally:

- `bad_format_5`:
  - passed once with Jenkins-like args.
  - then passed 20x.
- Full `gossiping_property_file_snitch_test`:
  - passed once
  - then passed 20x
  - then passed 1000x
  - then passed 10000x on 20 parallel workers.

Fixes SCYLLADB-2564