### PR TITLE
io_tester: disambiguate YAML sstring emission

### DIFF
--- a/apps/io_tester/io_tester.cc
+++ b/apps/io_tester/io_tester.cc
@@ -679,7 +679,7 @@ private:
 
     void emit_one_metrics(YAML::Emitter& out, sstring m_name, bool check_class_metrics = true) {
         if (auto v = get_one_metrics(m_name, check_class_metrics); v.has_value()) {
-            out << YAML::Key << m_name << YAML::Value << *v;
+            out << YAML::Key << m_name.c_str() << YAML::Value << *v;
         }
     }
 
@@ -1140,7 +1140,8 @@ public:
     future<> emit_results(YAML::Emitter& out) {
         return _finished.wait(_cl.size()).then([this, &out] {
             for (auto& cl: _cl) {
-                out << YAML::Key << cl->name();
+                const auto name = cl->name();
+                out << YAML::Key << name.c_str();
                 out << YAML::BeginMap;
                 cl->emit_results(out);
                 out << YAML::EndMap;


### PR DESCRIPTION
This fixes the Alpine build failure caused by newer yaml-cpp versions exposing both std::string and std::string_view YAML::Emitter overloads. Passing seastar::sstring directly becomes ambiguous, so emit the YAML keys through c_str() to select the const char* overload explicitly.

Fixes: SCYLLADB-2641